### PR TITLE
Add "(meta)" to hot meta questions

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,7 +92,7 @@
           <div class="module__content">
             <ul>
               <% @hot_questions.each do |hq| %>
-                <li><%= link_to hq.title, question_path(hq) %></li>
+                <li><%= link_to hq.title, question_path(hq) %><% if hq.is_meta %> (meta)<% end %></li>
               <% end %>
             </ul>
           </div>


### PR DESCRIPTION
Some questions with relatively much activity are selected as hot questions and featured in the side bar. This also applies to meta questions, however they are not good distinguishable from main questions. (https://qpixel.artofcode.co.uk/questions/39229)

This PR adds a little `(meta)` label behind them to distinguish them.