### PR TITLE
Prevent container overflow for images

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -222,3 +222,9 @@ footer {
     }
   }
 }
+
+/* Prevent container overflow for images */
+img {
+    max-width: 100%;
+    height: auto;
+}


### PR DESCRIPTION
When an image is larger than the surrounding container, it will overflow it by default. This change will prevent this from happening by resizing the image to 100% when it is larger than the container.

Example for where this happened: http://writing.codidact.com/questions/36723

This should not have any side effects and has been tested in latest Firefox, Chrome and Edge.